### PR TITLE
More fixes for using wicd under Python 3, mostly in the daemon

### DIFF
--- a/curses/curses_misc.py
+++ b/curses/curses_misc.py
@@ -707,7 +707,7 @@ class OptCols(urwid.WidgetWrap):
         # callbacks map the text contents to its assigned callback.
         self.callbacks = []
         for cmd in tuples:
-            key = reduce(lambda s, (f, t): s.replace(f, t), [
+            key = reduce(lambda s, tuple: s.replace(tuple[0], tuple[1]), [
                 ('ctrl ', 'Ctrl+'), ('meta ', 'Alt+'),
                 ('left', '<-'), ('right', '->'),
                 ('page up', 'Page Up'), ('page down', 'Page Down'),

--- a/curses/wicd-curses.py
+++ b/curses/wicd-curses.py
@@ -46,7 +46,7 @@ import urwid
 # DBus communication stuff
 from dbus import DBusException
 # It took me a while to figure out that I have to use this.
-import gobject
+from gi.repository import GObject as gobject
 
 # Other important wicd-related stuff
 from wicd import wpath

--- a/gtk/gui.py
+++ b/gtk/gui.py
@@ -26,7 +26,7 @@ Module containing the code for the main wicd GUI.
 import os
 import sys
 import time
-import gobject
+from gi.repository import GObject as gobject
 import gtk
 from itertools import chain
 from dbus import DBusException

--- a/gtk/prefs.py
+++ b/gtk/prefs.py
@@ -25,7 +25,7 @@ handles recieving/sendings the settings from/to the daemon.
 #
 
 import gtk
-import gobject
+from gi.repository import GObject as gobject
 import os
 
 from wicd import misc

--- a/gtk/wicd-client.py
+++ b/gtk/wicd-client.py
@@ -39,7 +39,7 @@ class TrayIcon() -- Parent class of TrayIconGUI and IconConnectionInfo.
 
 import sys
 import gtk
-import gobject
+from gi.repository import GObject as gobject
 import getopt
 import os
 import pango

--- a/setup.py
+++ b/setup.py
@@ -231,36 +231,36 @@ class configure(Command):
             pmtemp = subprocess.Popen(["pkg-config", "--variable=pm_sleephooks", 
                                        "pm-utils"], stdout=subprocess.PIPE)
             returncode = pmtemp.wait() # let it finish, and get the exit code
-            pmutils_candidate = pmtemp.stdout.readline().strip() # read stdout
+            pmutils_candidate = str(pmtemp.stdout.readline().strip()) # read stdout
             if len(pmutils_candidate) == 0 or returncode != 0 or \
                not os.path.isabs(pmutils_candidate):
                 raise ValueError
             else:
                 self.pmutils = pmutils_candidate
-        except (OSError, ValueError):
+        except (OSError, ValueError, FileNotFoundError):
             pass # use our default
 
         try:
             kdetemp = subprocess.Popen(["kde-config","--prefix"], stdout=subprocess.PIPE)
             returncode = kdetemp.wait() # let it finish, and get the exit code
-            kdedir_candidate = kdetemp.stdout.readline().strip() # read stdout
+            kdedir_candidate = str(kdetemp.stdout.readline().strip()) # read stdout
             if len(kdedir_candidate) == 0 or returncode != 0 or \
                not os.path.isabs(kdedir_candidate):
                 raise ValueError
             else:
                 self.kdedir = kdedir_candidate + '/share/autostart'
-        except (OSError, ValueError):
+        except (OSError, ValueError, FileNotFoundError):
             # If kde-config isn't present, we'll check for kde-4.x
             try:
                 kde4temp = subprocess.Popen(["kde4-config","--prefix"], stdout=subprocess.PIPE)
                 returncode = kde4temp.wait() # let it finish, and get the exit code
-                kde4dir_candidate = kde4temp.stdout.readline().strip() # read stdout
+                kde4dir_candidate = str(kde4temp.stdout.readline().strip()) # read stdout
                 if len(kde4dir_candidate) == 0 or returncode != 0 or \
                    not os.path.isabs(kde4dir_candidate):
                     raise ValueError
                 else:
                     self.kdedir = kde4dir_candidate + '/share/autostart'
-            except (OSError, ValueError):
+            except (OSError, ValueError, FileNotFoundError):
                 # If neither kde-config nor kde4-config are not present or 
                 # return an error, then we can assume that kde isn't installed
                 # on the user's system
@@ -339,9 +339,9 @@ class configure(Command):
             # if the option is not python (which is not a directory)
             if not argument[0][:-1] == "python":
                 # see if it ends with a /
-                if not value.endswith("/"):
+                if not str(value).endswith("/"):
                     # if it doesn't, slap one on
-                    setattr(self, argument_name, value + "/")
+                    setattr(self, argument_name, str(value) + "/")
             else:
                 # as stated above, the python entry defines the beginning
                 # of the files section
@@ -636,7 +636,7 @@ class compile_translations(Command):
                         print(len(output), returncode)
                         raise ValueError
                     else:
-                        m = re.match('(\d+) translated messages(?:, (\d+) fuzzy translation)?(?:, (\d+) untranslated messages)?.', output)
+                        m = re.match(b'(\d+) translated messages(?:, (\d+) fuzzy translation)?(?:, (\d+) untranslated messages)?.', output)
                         if m:
                             done, fuzzy, missing = m.groups()
                             fuzzy = int(fuzzy) if fuzzy else 0

--- a/wicd/logfile.py
+++ b/wicd/logfile.py
@@ -53,7 +53,7 @@ class LogFile(io.FileIO):
         if len(data) <= 0:
             return
         if self.eol:
-            super(LogFile, self).write(self.get_time() + ' :: ')
+            super(LogFile, self).write(self.get_time().encode("utf-8") + b' :: ')
             self.eol = False
 
         if data[-1] == '\n':
@@ -61,7 +61,7 @@ class LogFile(io.FileIO):
             data = data[:-1]
 
         super(LogFile, self).write(data.replace(
-                                    '\n', '\n' + self.get_time() + ' :: '))
+                                    b'\n', b'\n' + self.get_time().encode("utf-8") + b' :: '))
         if self.eol:
             super(LogFile, self).write('\n')
             

--- a/wicd/logfile.py
+++ b/wicd/logfile.py
@@ -24,20 +24,21 @@ rotates itself when a maximum size is reached.
 import sys
 import os
 import time
+import io
 
 class SizeError(IOError):
     """ Custom error class. """
     pass
 
-class LogFile:
+class LogFile(io.FileIO):
     """LogFile(name, [mode="w"], [maxsize=360000])
     
     Opens a new file object. After writing <maxsize> bytes a SizeError
     will be raised.
     
     """
-    def __init__(self, name, mode="a", maxsize=360000):
-        super(LogFile, self).__init__(name, mode)
+    def __init__(self, name, mode="a", maxsize=360000, *args, **kwargs):
+        super(LogFile, self).__init__(name, mode, maxsize, *args, **kwargs)
         self.maxsize = maxsize
         self.eol = True
         try:

--- a/wicd/monitor.py
+++ b/wicd/monitor.py
@@ -24,7 +24,7 @@ when appropriate.
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import gobject
+from gi.repository import GObject as gobject
 import time
 
 from dbus import DBusException

--- a/wicd/networking.py
+++ b/wicd/networking.py
@@ -644,7 +644,8 @@ class Wireless(Controller):
                 key = 'quality'
             else:
                 key = 'strength'
-            return cmp(x[key], y[key])
+            return ((x[key] > y[key]) - (x[key] < y[key])) # cmp(x[key], y[key])
+
                 
         if not self.wiface:
             return []

--- a/wicd/networking.py
+++ b/wicd/networking.py
@@ -48,6 +48,7 @@ import time
 import threading
 import os
 from signal import SIGTERM
+from functools import cmp_to_key
 
 # wicd imports 
 from . import misc
@@ -663,7 +664,7 @@ class Wireless(Controller):
             time.sleep(1)
 
         aps = wiface.GetNetworks(essid)
-        aps.sort(cmp=comp, reverse=True)
+        aps.sort(key=cmp_to_key(comp), reverse=True)
         
         return aps
 

--- a/wicd/wicd-daemon.py
+++ b/wicd/wicd-daemon.py
@@ -44,7 +44,7 @@ from subprocess import Popen
 from operator import itemgetter
 
 # DBUS
-import gobject
+from gi.repository import GObject as gobject
 import dbus
 import dbus.service
 if getattr(dbus, 'version', (0, 0, 0)) < (0, 80, 0):
@@ -1950,5 +1950,7 @@ if __name__ == '__main__':
         print(("Root privileges are required for the daemon to run properly." +
                "  Exiting."))
         sys.exit(1)
-    gobject.threads_init()
+    # No more needed since PyGObject 3.11, c.f.
+    # https://wiki.gnome.org/PyGObject/Threading
+    #gobject.threads_init()
     main(sys.argv)

--- a/wicd/wnettools.py
+++ b/wicd/wnettools.py
@@ -39,7 +39,7 @@ import dbus
 import socket, fcntl
 import shutil
 
-import wpath
+from . import wpath
 from . import misc
 from .misc import find_path 
 

--- a/wicd/wnettools.py
+++ b/wicd/wnettools.py
@@ -38,6 +38,7 @@ import time
 import dbus
 import socket, fcntl
 import shutil
+from functools import cmp_to_key
 
 from . import wpath
 from . import misc
@@ -1444,7 +1445,7 @@ class BaseWirelessInterface(BaseInterface):
         m = re.findall(bitrates_pattern, bitrates)
         if m:
             # numeric sort
-            ap['bitrates'] = sorted(m, lambda x, y: int(float(x) - float(y)))
+            ap['bitrates'] = sorted(m, key=cmp_to_key(lambda x, y: int(float(x) - float(y))))
         else:
             ap['bitrates'] = None
 


### PR DESCRIPTION
All patches are coming from Debian's python3 branch at https://salsa.debian.org/debian/wicd/commits/python3

The only thing I haven't included yet in this fork are the changed shebang lines which need to be `python3` instead of just `python` at least as of now on Debian. Can add that as a commit to this or a new pull request, though.

`wicd-curses` still throws deprecation warnings for me:

```
/usr/share/wicd/curses/wicd-curses.py:1249: PyGIDeprecationWarning: GObject.timeout_add is deprecated; use GLib.timeout_add instead
  gobject.timeout_add(2000, app.update_status)
/usr/share/wicd/curses/wicd-curses.py:1254: PyGIDeprecationWarning: GObject.io_add_watch is deprecated; use GLib.io_add_watch instead
  gobject.io_add_watch(fd, gobject.IO_IN, app.call_update_ui)
/usr/share/wicd/curses/wicd-curses.py:1254: PyGIDeprecationWarning: GObject.IO_IN is deprecated; use GLib.IO_IN instead
  gobject.io_add_watch(fd, gobject.IO_IN, app.call_update_ui)
```

Might fix that later — unless someone else fixes it first.