### PR TITLE
Fix wicd-curses warnings in status bar and similar cases

### DIFF
--- a/curses/wicd-curses.py
+++ b/curses/wicd-curses.py
@@ -46,7 +46,7 @@ import urwid
 # DBus communication stuff
 from dbus import DBusException
 # It took me a while to figure out that I have to use this.
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 
 # Other important wicd-related stuff
 from wicd import wpath

--- a/gtk/gui.py
+++ b/gtk/gui.py
@@ -26,7 +26,7 @@ Module containing the code for the main wicd GUI.
 import os
 import sys
 import time
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 import gtk
 from itertools import chain
 from dbus import DBusException

--- a/gtk/wicd-client.py
+++ b/gtk/wicd-client.py
@@ -39,7 +39,7 @@ class TrayIcon() -- Parent class of TrayIconGUI and IconConnectionInfo.
 
 import sys
 import gtk
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 import getopt
 import os
 import pango

--- a/wicd/misc.py
+++ b/wicd/misc.py
@@ -27,7 +27,7 @@ import locale
 import sys
 import re
 import string
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 from threading import Thread
 from subprocess import Popen, STDOUT, PIPE, call
 from subprocess import getoutput

--- a/wicd/monitor.py
+++ b/wicd/monitor.py
@@ -24,7 +24,7 @@ when appropriate.
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 import time
 
 from dbus import DBusException

--- a/wicd/wicd-daemon.py
+++ b/wicd/wicd-daemon.py
@@ -44,7 +44,7 @@ from subprocess import Popen
 from operator import itemgetter
 
 # DBUS
-from gi.repository import GObject as gobject
+from gi.repository import GLib as gobject
 import dbus
 import dbus.service
 if getattr(dbus, 'version', (0, 0, 0)) < (0, 80, 0):


### PR DESCRIPTION
Replace all occurrences of `from gi.repository import GObject as
gobject` with `from gi.repository import GLib as gobject`.